### PR TITLE
Fixed no_stamina disabling shield gauge

### DIFF
--- a/game/Player.cpp
+++ b/game/Player.cpp
@@ -1632,7 +1632,7 @@ void idPlayer::Init( void ) {
 	}
 	// disable stamina on hell levels
 	if ( gameLocal.world && gameLocal.world->spawnArgs.GetBool( "no_stamina" ) ) {
-		pm_stamina.SetFloat( 0.0f );
+		//pm_stamina.SetFloat( 0.0f );  //revility 2020 stamina in Rivensin is used for energy shield gauge.
 	}
 
 	// stamina always initialized to maximum


### PR DESCRIPTION
Commented out the no_stamina bit.  Stamina in Rivensin is used for the energy shield and not running.  If this was set in a map, the shield was disabled.  Noticeable if playing some user made maps and Hell levels in vanilla campaign.