### PR TITLE
weapons may cast shadows now

### DIFF
--- a/game/Weapon.cpp
+++ b/game/Weapon.cpp
@@ -921,8 +921,9 @@ void idWeapon::Clear( void ) {
 	memset( &renderEntity, 0, sizeof( renderEntity ) );
 	renderEntity.entityNum	= entityNumber;
 
-	renderEntity.noShadow		= true;
-	renderEntity.noSelfShadow	= true;
+//rev 2020 enable weapons to cast shadows
+	renderEntity.noShadow		= false;	//true;
+	renderEntity.noSelfShadow	= false;	//true;
 	renderEntity.customSkin		= NULL;
 
 	// set default shader parms


### PR DESCRIPTION
Player weapons can now cast shadows.  Materials might need to be updated as well to fully work.