### PR TITLE
Real Gibs - source code

### DIFF
--- a/game/AFEntity.cpp
+++ b/game/AFEntity.cpp
@@ -1191,14 +1191,20 @@ void idAFEntity_Gibbable::Gib( const idVec3 &dir, const char *damageDefName ) {
 	UnlinkCombat();
 
 	if ( g_bloodEffects.GetBool() ) {
-		if ( gameLocal.time > gameLocal.GetGibTime() ) {
+		// Real Gibs - Taken from the repository (https://github.com/RobertBeckebans/Sikkpin-Feedback)
+		// sikk - Since "nextGibTime" is a member of idGameLocal and not idAFEntity||idAFEntity_Gibbable
+		// the folloing if statement is only true once per damage event instead of per entity being damaged.
+		// This is why only one entity will get gibbed while the rest just disappear after a few seconds.
+		// I commented this out instead of moving the variable to the proper class because it's easier and
+		// the delay is only 200ms so the difference should be unnoticable
+		//if ( gameLocal.time > gameLocal.GetGibTime() ) {
 			gameLocal.SetGibTime( gameLocal.time + GIB_DELAY );
 			SpawnGibs( dir, damageDefName );
 			renderEntity.noShadow = true;
 			renderEntity.shaderParms[ SHADERPARM_TIME_OF_DEATH ] = gameLocal.time * 0.001f;
 			StartSound( "snd_gibbed", SND_CHANNEL_ANY, 0, false, NULL );
 			gibbed = true;
-		}
+		//}
 	} else {
 		gibbed = true;
 	}

--- a/game/Actor.cpp
+++ b/game/Actor.cpp
@@ -2134,6 +2134,10 @@ void idActor::Gib( const idVec3 &dir, const char *damageDefName ) {
 	if ( head.GetEntity() ) {
 		head.GetEntity()->Hide();
 	}
+	// darknar
+	if (spawnArgs.GetBool("gib_remove")) {
+		Hide();
+	}
 	StopSound( SND_CHANNEL_VOICE, false );
 }
 
@@ -2191,7 +2195,7 @@ void idActor::Damage( idEntity *inflictor, idEntity *attacker, const idVec3 &dir
 				health = -999;
 			}
 			Killed( inflictor, attacker, damage, dir, location );
-			if ( ( health < -20 ) && spawnArgs.GetBool( "gib" ) && damageDef->GetBool( "gib" ) ) {
+			if ( ( health < spawnArgs.GetInt("health_gib") ) && spawnArgs.GetBool( "gib" ) && damageDef->GetBool( "gib" ) ) { // darknar
 				Gib( dir, damageDefName );
 			}
 		} else {

--- a/game/Item.h
+++ b/game/Item.h
@@ -161,6 +161,7 @@ public:
 
 	void					Spawn( void );
 	virtual void			Think( void );
+	virtual bool			Collide( const trace_t &collision, const idVec3 &velocity ); // darknar, probably this can be useful if the splat fx moveable gib was causing lag. Allow idMoveableItem class spawn fx on collision
 	virtual bool			Pickup( idPlayer *player );
 
 	static void				DropItems( idAnimatedEntity *ent, const char *type, idList<idEntity *> *list );
@@ -174,7 +175,8 @@ private:
 	idClipModel *			trigger;
 	const idDeclParticle *	smoke;
 	int						smokeTime;
-
+	int						nextSoundTime; // darknar, fx collide data
+	idStr					fxCollide; // darknar, fx collide data
 	void					Gib( const idVec3 &dir, const char *damageDefName );
 
 	void					Event_DropToFloor( void );
@@ -225,5 +227,21 @@ private:
 	void					Event_HideObjective( idEntity *e );
 	void					Event_GetPlayerPos();
 };
+
+// darknar start change
+
+/*
+===============================================================================
+
+idMoveableGibItem
+
+===============================================================================
+*/
+class idMoveableGibItem : public idMoveableItem {
+public:
+	CLASS_PROTOTYPE(idMoveableGibItem);
+};
+
+// darknar end change
 
 #endif /* !__GAME_ITEM_H__ */

--- a/game/Moveable.cpp
+++ b/game/Moveable.cpp
@@ -175,6 +175,10 @@ void idMoveable::Spawn( void ) {
 	if ( spawnArgs.GetBool( "nonsolid" ) ) {
 		BecomeNonSolid();
 	}
+		if ( spawnArgs.GetBool( "gibclear" ) ) { // makes the moveable burn at spawn, i don't know if this works!!!
+		GetRenderEntity()->shaderParms[SHADERPARM_TIME_OF_DEATH] = gameLocal.time * 0.001f; // darknar, test custom gib clear for splat moveable for optimization
+		PostEventMS( &EV_Remove, 4000 ); // darknar, remove this after 4 seconds
+	}
 
 	allowStep = spawnArgs.GetBool( "allowStep", "1" );
 

--- a/game/Moveable.cpp
+++ b/game/Moveable.cpp
@@ -175,7 +175,7 @@ void idMoveable::Spawn( void ) {
 	if ( spawnArgs.GetBool( "nonsolid" ) ) {
 		BecomeNonSolid();
 	}
-		if ( spawnArgs.GetBool( "gibclear" ) ) { // makes the moveable burn at spawn, i don't know if this works!!!
+	if ( spawnArgs.GetBool( "gibclear" ) ) { // makes the moveable burn at spawn, i don't know if this works!!!
 		GetRenderEntity()->shaderParms[SHADERPARM_TIME_OF_DEATH] = gameLocal.time * 0.001f; // darknar, test custom gib clear for splat moveable for optimization
 		PostEventMS( &EV_Remove, 4000 ); // darknar, remove this after 4 seconds
 	}

--- a/game/Mover.cpp
+++ b/game/Mover.cpp
@@ -1004,6 +1004,9 @@ void idMover::Event_PartBlocked( idEntity *blockingEntity ) {
 	if ( g_debugMover.GetBool() ) {
 		gameLocal.Printf( "%d: '%s' blocked by '%s'\n", gameLocal.time, name.c_str(), blockingEntity->name.c_str() );
 	}
+	if ( blockingEntity->IsType( idMoveableGibItem::Type ) ) { // darknar, remove gib if is blocking the mover
+		blockingEntity->PostEventMS( &EV_Remove, 0 );
+	}
 }
 
 /*
@@ -3790,6 +3793,9 @@ void idDoor::Event_PartBlocked( idEntity *blockingEntity ) {
 	if ( damage > 0.0f ) {
 		blockingEntity->Damage( this, this, vec3_origin, "damage_moverCrush", damage, INVALID_JOINT );
 	}
+	if ( blockingEntity->IsType( idMoveableGibItem::Type ) ) { // darknar, remove gib if is blocking the mover
+		blockingEntity->PostEventMS( &EV_Remove, 0 );
+	}
 }
 
 /*
@@ -4227,6 +4233,9 @@ void idPlat::Event_PartBlocked( idEntity *blockingEntity ) {
 	if ( damage > 0.0f ) {
 		blockingEntity->Damage( this, this, vec3_origin, "damage_moverCrush", damage, INVALID_JOINT );
 	}
+	if ( blockingEntity->IsType( idMoveableGibItem::Type ) ) { // darknar, remove gib if is blocking the mover
+		blockingEntity->PostEventMS( &EV_Remove, 0 );
+	}
 }
 
 
@@ -4317,6 +4326,9 @@ idMover_Periodic::Event_PartBlocked
 void idMover_Periodic::Event_PartBlocked( idEntity *blockingEntity ) {
 	if ( damage > 0.0f ) {
 		blockingEntity->Damage( this, this, vec3_origin, "damage_moverCrush", damage, INVALID_JOINT );
+	}
+	if ( blockingEntity->IsType( idMoveableGibItem::Type ) ) { // darknar remove gib if is blocking the mover
+		blockingEntity->PostEventMS( &EV_Remove, 0 );
 	}
 }
 

--- a/game/gamesys/SysCmds.cpp
+++ b/game/gamesys/SysCmds.cpp
@@ -261,6 +261,22 @@ void Cmd_KillMovables_f( const idCmdArgs &args ) {
 	KillEntities( args, idMoveable::Type );
 }
 
+// darknar start change
+/*
+==================
+Cmd_ClearGibs_f
+
+Kill all gib moveable in a level.
+==================
+*/
+void Cmd_ClearGibs_f( const idCmdArgs &args ) {
+	if ( !gameLocal.GetLocalPlayer() ) {
+		return;
+	}
+	KillEntities( args, idMoveableGibItem::Type );
+}
+// darknar end change
+
 /*
 ==================
 Cmd_KillRagdolls_f
@@ -2334,6 +2350,13 @@ void idGameLocal::InitConsoleCommands( void ) {
 	cmdSystem->AddCommand( "remove",				Cmd_Remove_f,				CMD_FL_GAME|CMD_FL_CHEAT,	"removes an entity", idGameLocal::ArgCompletion_EntityName );
 	cmdSystem->AddCommand( "killMonsters",			Cmd_KillMonsters_f,			CMD_FL_GAME|CMD_FL_CHEAT,	"removes all monsters" );
 	cmdSystem->AddCommand( "killMoveables",			Cmd_KillMovables_f,			CMD_FL_GAME|CMD_FL_CHEAT,	"removes all moveables" );
+
+	// darlnar start change
+
+	cmdSystem->AddCommand( "ClearGibs",             Cmd_ClearGibs_f,            CMD_FL_GAME|CMD_FL_CHEAT,   "removes all gibs spawned" );
+
+	// darknar end change
+	
 	cmdSystem->AddCommand( "killRagdolls",			Cmd_KillRagdolls_f,			CMD_FL_GAME|CMD_FL_CHEAT,	"removes all ragdolls" );
 	cmdSystem->AddCommand( "addline",				Cmd_AddDebugLine_f,			CMD_FL_GAME|CMD_FL_CHEAT,	"adds a debug line" );
 	cmdSystem->AddCommand( "addarrow",				Cmd_AddDebugLine_f,			CMD_FL_GAME|CMD_FL_CHEAT,	"adds a debug arrow" );

--- a/game/gamesys/SysCvar.cpp
+++ b/game/gamesys/SysCvar.cpp
@@ -335,3 +335,8 @@ idCVar mod_validSkins(				"mod_validSkins",			"skins/characters/player/marine_mp
 idCVar net_serverDownload(			"net_serverDownload",		"0",			CVAR_GAME | CVAR_INTEGER | CVAR_ARCHIVE, "enable server download redirects. 0: off 1: redirect to si_serverURL 2: use builtin download. see net_serverDl cvars for configuration" );
 idCVar net_serverDlBaseURL(			"net_serverDlBaseURL",		"",				CVAR_GAME | CVAR_ARCHIVE, "base URL for the download redirection" );
 idCVar net_serverDlTable(			"net_serverDlTable",		"",				CVAR_GAME | CVAR_ARCHIVE, "pak names for which download is provided, separated by ;" );
+
+// darknar add
+idCVar g_gib_power(                 "g_gib_power",              "75.0",         CVAR_GAME | CVAR_NOCHEAT | CVAR_ARCHIVE | CVAR_FLOAT, "gibs are launched with this force when the monster gibs, default is 75.0" );
+idCVar g_gib_shadows(               "g_gib_shadows",            "0",            CVAR_GAME | CVAR_NOCHEAT | CVAR_ARCHIVE | CVAR_BOOL, "enable shadows for spawned gibs, default is 0, no shadows" );
+idCVar g_gib_remove_time(           "g_gib_remove_time",        "0.0",          CVAR_GAME | CVAR_NOCHEAT | CVAR_ARCHIVE | CVAR_FLOAT, "remove the gibs after x seconds, default is 0.0" );

--- a/game/gamesys/SysCvar.h
+++ b/game/gamesys/SysCvar.h
@@ -250,6 +250,11 @@ extern idCVar	si_spectators;
 extern idCVar	net_clientSelfSmoothing;
 extern idCVar	net_clientLagOMeter;
 
+// darknar add
+extern idCVar   g_gib_power;
+extern idCVar   g_gib_shadows;
+extern idCVar   g_gib_remove_time;
+
 extern const char *si_gameTypeArgs[];
 
 extern const char *ui_skinArgs[];


### PR DESCRIPTION
This code provided by the developer includes  gibbing settings as well as attempts to optimize the performance of this mod


This code does not yet have damage based on body location! You can customize your gameplay with these commands:

g_gib_power - Initial speed of gibs spread

g_gib_shadows - On/Off gibs shadows

g_gib_remove_time - Time to remove gibs

cleargibs - remove all gibs

health_gib - Sets the value at which monsters will be gibbing. You can set it to -20 like in the original game or more if you want. All changes healthgib must be made in def files and not in the console!


The mod itself can be found at - https://www.moddb.com/games/doom-iii/addons/real-gibs-v106-for-dhewm3-32-bit